### PR TITLE
Drop OpenRLA given shift to alternate sampler.py

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,9 +5,6 @@
 	path = 2018-bctool
 	url = https://github.com/ElectionAuditWare/2018-bctool
 	branch = website
-[submodule "OpenRLA"]
-	path = OpenRLA
-	url = https://github.com/ElectionAuditWare/OpenRLA
 [submodule "RIWAVE"]
 	path = RIWAVE
 	url = https://github.com/zperumal/RIWAVE


### PR DESCRIPTION
After upgrading to this version, run 

    git rm --cached OpenRLA

to avoid a likely `fatal: No url found for submodule path 'OpenRLA....`

See use of  rivest-sampler-tests sampler.py via daeb8c9

Resolves: #5