### PR TITLE
Add to README.md: git submodule sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ Maybe todo:
   - (mini)conda
   - Debian/Ubuntu packages
 
+## Upgrades:
+
+If the `.gitmodules` file is updated, run this:
+
+    git submodule sync
+
+Any time one of the submodules might have changed, run
+
+    git submodule update --init --recursive
+
+
 ## Tests
 
 You can run the tests by calling


### PR DESCRIPTION
See: [How to change the remote repository for a git submodule? - Stack Overflow](https://stackoverflow.com/questions/913701/how-to-change-the-remote-repository-for-a-git-submodule)

as needed due to the new location for RIWAVE (added in commit 41b1798)