### PR TITLE
revert some previous UI changes which break server

### DIFF
--- a/ui/rla_ui.js
+++ b/ui/rla_ui.js
@@ -706,7 +706,7 @@ function newRaceCheckbox(ballot_id, race_id, race_title, race_choices) {
    ul = newElem('ul');
    ul.setAttribute('style', 'list-style-type: none');
    div.appendChild(ul);
-   race_choices.concat(['Write-in candidate', 'No selection (undervote)', 'Overvote']).forEach(function(choice,i) {
+   race_choices.concat(['Write-in', 'undervote', 'overvote']).forEach(function(choice,i) {
       if(!(race_id.includes('issue')&&choice.includes('Write-in'))){
       //race_choices.forEach(function(choice,i) {
       var checkbox, label, li;
@@ -720,7 +720,7 @@ function newRaceCheckbox(ballot_id, race_id, race_title, race_choices) {
       checkbox.value = choice;
 
       label = newElem('label');
-      label.innerHTML = prettifyChoice(choice); // again, careful!
+      label.innerHTML = choice; // again, careful!
       label.setAttribute('for', checkbox.id);
       label.classList.add('choiceCheckboxLabel');
 


### PR DESCRIPTION
The UI changes are causing the back-end to break because the specific "undervote" and "overvote" formats are hard-coded into the Comparison.py and BallotPolling.py in RIWAVE